### PR TITLE
add unicode support to regolith/install.sh

### DIFF
--- a/configs/regolith/install.sh
+++ b/configs/regolith/install.sh
@@ -8,6 +8,9 @@ cp cyber.jpg ~/Pictures/cyber.jpg
 # make the the top bar look better
 sudo apt remove i3xrocks-app-launcher i3xrocks-net-traffic i3xrocks-info i3xrocks-next-workspace
 
+# add full unicode support
+sudo apt install fonts-noto
+
 # terminal colors
 sudo apt-get install dconf-cli uuid-runtime -y
 bash -c "$(wget -qO- https://git.io/vQgMr)"


### PR DESCRIPTION
Added an apt install to the regolith/install.sh script that will enable non-latin unicode chars to render properly.

Feel free to move the line to a different file or drop the pull altogether @mahaloz.