### PR TITLE
Add `fonts-noto` to `install_commons.sh` for better Unicode support

### DIFF
--- a/configs/regolith/install.sh
+++ b/configs/regolith/install.sh
@@ -8,9 +8,6 @@ cp cyber.jpg ~/Pictures/cyber.jpg
 # make the the top bar look better
 sudo apt remove i3xrocks-app-launcher i3xrocks-net-traffic i3xrocks-info i3xrocks-next-workspace
 
-# add full unicode support
-sudo apt install fonts-noto
-
 # terminal colors
 sudo apt-get install dconf-cli uuid-runtime -y
 bash -c "$(wget -qO- https://git.io/vQgMr)"

--- a/configs/regolith/install.sh
+++ b/configs/regolith/install.sh
@@ -8,6 +8,9 @@ cp cyber.jpg ~/Pictures/cyber.jpg
 # make the the top bar look better
 sudo apt remove i3xrocks-app-launcher i3xrocks-net-traffic i3xrocks-info i3xrocks-next-workspace
 
+# add full unicode support
+sudo apt install fonts-noto
+
 # terminal colors
 sudo apt-get install dconf-cli uuid-runtime -y
 bash -c "$(wget -qO- https://git.io/vQgMr)"

--- a/install_commons.sh
+++ b/install_commons.sh
@@ -21,6 +21,7 @@ sudo apt-get install -y \
     python3 \
     python3-pip \
     ipython3 \
-    tmux
+    tmux \
+    fonts-noto
 
 python3 -m pip install sortedcontainers ipdb


### PR DESCRIPTION
Added `fonts-noto` to the list of apt libraries installed in `install_commons.sh`.

- Enables non-latin unicode chars to display properly in most situations.